### PR TITLE
added 'senaste' scrolling sponsored content to all news filters

### DIFF
--- a/wsgi/iportalen_django/articles/templates/articles/articles.html
+++ b/wsgi/iportalen_django/articles/templates/articles/articles.html
@@ -4,6 +4,20 @@
 
 {% block content %}
     <section id="news-feed">
+        {% get_sponsored_content as sponsored_content %}
+        <div class="sponsored_container">
+            <div id="sponsored_feed_container" class="sponsored_feed_container" style="display: none;" >
+                <div class="sponsored_feed_headline"><a href="{% url "sponsored" %}" class="content-type-nav">Senaste:</a></div>
+                <div id="sponsored_feed_content">
+                    <ul style="display: block; overflow: hidden">
+                        {% for c in sponsored_content %}
+                            <li><strong><a href="{{ c.get_absolute_url }}">{{ c.headline|truncatechars:62 }}</a></strong></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            <hr>
+        </div>
         <div id="content-select-nav">
             <a href="{% url "news feed" %}" class="content-type-nav">Allt</a>
             <a href="{% url "articles:articles" %}" class="content-type-nav active">Nyheter</a>
@@ -15,4 +29,7 @@
             {% include "articles/model/small_article.html" with article=article %}
         {% endfor %}
     </section>
+{% endblock %}
+{% block document_ready %}
+    expander_trigger_news_page('{% url 'news api' %}')
 {% endblock %}

--- a/wsgi/iportalen_django/events/templates/events/calender.html
+++ b/wsgi/iportalen_django/events/templates/events/calender.html
@@ -1,10 +1,25 @@
 {% extends "master.html" %}
 {# This file defines the front page and is a own kind of master page #}
+{% load iportalen_tags %}
 {% load event_tags %}
 {% include "header.html" %}
 
 {% block content %}
     <section id="news-feed">
+        {% get_sponsored_content as sponsored_content %}
+        <div class="sponsored_container">
+            <div id="sponsored_feed_container" class="sponsored_feed_container" style="display: none;" >
+                <div class="sponsored_feed_headline"><a href="{% url "sponsored" %}" class="content-type-nav">Senaste:</a></div>
+                <div id="sponsored_feed_content">
+                    <ul style="display: block; overflow: hidden">
+                        {% for c in sponsored_content %}
+                            <li><strong><a href="{{ c.get_absolute_url }}">{{ c.headline|truncatechars:62 }}</a></strong></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            <hr>
+        </div>
         <div id="content-select-nav">
             <a href="{% url "news feed" %}" class="content-type-nav">Allt</a>
             <a href="{% url "articles:articles" %}" class="content-type-nav">Nyheter</a>
@@ -17,4 +32,7 @@
             {% include "events/model/small_event.html" with event=event %}
         {% endfor %}
     </section>
+{% endblock %}
+{% block document_ready %}
+    expander_trigger_news_page('{% url 'news api' %}')
 {% endblock %}

--- a/wsgi/templates/job_adverts.html
+++ b/wsgi/templates/job_adverts.html
@@ -6,6 +6,20 @@
 {% block content %}
     {# gets all articles via template tag #}
     <section id="news-feed">
+        {% get_sponsored_content as sponsored_content %}
+        <div class="sponsored_container">
+            <div id="sponsored_feed_container" class="sponsored_feed_container" style="display: none;" >
+                <div class="sponsored_feed_headline"><a href="{% url "sponsored" %}" class="content-type-nav">Senaste:</a></div>
+                <div id="sponsored_feed_content">
+                    <ul style="display: block; overflow: hidden">
+                        {% for c in sponsored_content %}
+                            <li><strong><a href="{{ c.get_absolute_url }}">{{ c.headline|truncatechars:62 }}</a></strong></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            <hr>
+        </div>
         <div id="content-select-nav">
             <a href="{% url "news feed" %}" class="content-type-nav">Allt</a>
             <a href="{% url "articles:articles" %}" class="content-type-nav">Nyheter</a>
@@ -43,4 +57,7 @@
         </div>
     </section>
 
+{% endblock %}
+{% block document_ready %}
+        expander_trigger_news_page('{% url 'news api' %}')
 {% endblock %}

--- a/wsgi/templates/sponsored.html
+++ b/wsgi/templates/sponsored.html
@@ -6,6 +6,20 @@
 {% block content %}
     {# gets all articles via template tag #}
     <section id="news-feed">
+        {% get_sponsored_content as sponsored_content %}
+        <div class="sponsored_container">
+            <div id="sponsored_feed_container" class="sponsored_feed_container" style="display: none;" >
+                <div class="sponsored_feed_headline"><a href="{% url "sponsored" %}" class="content-type-nav">Senaste:</a></div>
+                <div id="sponsored_feed_content">
+                    <ul style="display: block; overflow: hidden">
+                        {% for c in sponsored_content %}
+                            <li><strong><a href="{{ c.get_absolute_url }}">{{ c.headline|truncatechars:62 }}</a></strong></li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            <hr>
+        </div>
         <div id="content-select-nav">
             <a href="{% url "news feed" %}" class="content-type-nav">Allt</a>
             <a href="{% url "articles:articles" %}" class="content-type-nav">Nyheter</a>
@@ -43,4 +57,7 @@
         </div>
     </section>
 
+{% endblock %}
+{% block document_ready %}
+        expander_trigger_news_page('{% url 'news api' %}')
 {% endblock %}


### PR DESCRIPTION
Nu ska det rullande sponsrade content finnas på alla rubriker, dvs nyheter, event, jobbannonser och näringsliv